### PR TITLE
파일 크기에 따른 프로토콜 변경

### DIFF
--- a/client/main/client.cpp
+++ b/client/main/client.cpp
@@ -10,7 +10,8 @@ using namespace std;
 bool askInformation(char *ip, int& port) {
 	// char tcpCheckStr[5] = {};
 	printf("IP: "); cin >> ip;
-	printf("PORT: "); cin >> port;
+	// printf("PORT: "); cin >> port;
+	port = PORT_NUMBER;
 	// printf("using TCP? (y/n):"); cin >> tcpCheckStr;
 	getchar(); fflush(stdin);
 	// return tcpCheckStr[0] == 'y' || tcpCheckStr[0] == 'Y';
@@ -43,14 +44,14 @@ int main() {
 		fgets(echoString, STRING_LENGTH, stdin);
 		echoString[strlen(echoString) - 1] = 0;
 
-		ClientRequestSwitchProtocol(&usingTCP, sock, echoServAddr, PORT, servIP);
-
 		/* Send the string, including the null terminator, to the server */
 		long long fileSize = 0LL;
 		if (dirExists(echoString))
 			fileSize = SendDirectoryToServer(usingTCP, echoString, sock, echoServAddr, fromSize);
-		else
+		else {
 			fileSize = SendFileToServer(usingTCP, echoString, sock, echoServAddr, fromSize);
+			continue;
+		}
 		if (fileSize <= 0) continue;
 
 		/* Recv a response */

--- a/client/main/client.cpp
+++ b/client/main/client.cpp
@@ -8,38 +8,13 @@
 using namespace std;
 
 bool askInformation(char *ip, int& port) {
-	char tcpCheckStr[5] = {};
+	// char tcpCheckStr[5] = {};
 	printf("IP: "); cin >> ip;
 	printf("PORT: "); cin >> port;
-	printf("using TCP? (y/n):"); cin >> tcpCheckStr;
+	// printf("using TCP? (y/n):"); cin >> tcpCheckStr;
 	getchar(); fflush(stdin);
-	return tcpCheckStr[0] == 'y' || tcpCheckStr[0] == 'Y';
-}
-
-void setUpSocket(bool isTCP, SOCKET& sock, sockaddr_in& address, char *servIP, int PORT) {
-	if (isTCP) {
-		if ((sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)) == INVALID_SOCKET)
-			ErrorHandling("socket() failed");
-
-		memset(&address, 0, sizeof(address));
-		address.sin_family = AF_INET;
-		address.sin_addr.s_addr = inet_addr(servIP);
-		address.sin_port = htons(PORT);
-
-		if (connect(sock, (sockaddr *)&address, sizeof(address)) == SOCKET_ERROR)
-			ErrorHandling("connect failed");
-	}
-	else {
-		/* Create a best-effort datagram socket using UDP */
-		if ((sock = socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP)) == INVALID_SOCKET)
-			ErrorHandling("socket() failed");
-
-		/* Construct the server address structure */
-		memset(&address, 0, sizeof(address));    /* Zero out structure */
-		address.sin_family = AF_INET;                 /* Internet address family */
-		address.sin_addr.S_un.S_addr = inet_addr(servIP);  /* Server IP address */
-		address.sin_port = htons(PORT);               /* Server port */
-	}
+	// return tcpCheckStr[0] == 'y' || tcpCheckStr[0] == 'Y';
+	return false;
 }
 
 int main() {
@@ -60,13 +35,15 @@ int main() {
 		ErrorHandling("WSAStartup() failed");
 	}
 
-	setUpSocket(usingTCP, sock, echoServAddr, servIP, PORT);
+	setUpSocket(usingTCP, sock, echoServAddr, PORT, servIP);
 
 	do {
 		fflush(stdout);
-		printf("파일 또는 디렉토리명> ");
+		printf("File or Directory Name> ");
 		fgets(echoString, STRING_LENGTH, stdin);
 		echoString[strlen(echoString) - 1] = 0;
+
+		ClientRequestSwitchProtocol(&usingTCP, sock, echoServAddr, PORT, servIP);
 
 		/* Send the string, including the null terminator, to the server */
 		long long fileSize = 0LL;

--- a/server/main/server.cpp
+++ b/server/main/server.cpp
@@ -8,9 +8,10 @@ using namespace std;
 
 bool askInformation(int& port) {
 	// char tcpCheckStr[5] = {};
-	printf("PORT: "); cin >> port;
+	// printf("PORT: "); cin >> port;
+	port = PORT_NUMBER;
 	// printf("using TCP? (y/n):"); cin >> tcpCheckStr;
-	getchar(); fflush(stdin);
+	// getchar(); fflush(stdin);
 	// return tcpCheckStr[0] == 'y' || tcpCheckStr[0] == 'Y';
 	return false;
 }
@@ -49,6 +50,8 @@ int main(){
 		if ((recvMsgSize = ServerReceiveFromClient(usingTCP, sock, echoBuffer, BUFFER_SIZE, clientSock, echoClntAddr, &cliLen)) == SOCKET_ERROR)
 			ErrorHandling("recvfrom() failed");
 
+		if (createServerDirectory(echoBuffer) == BEGIN_DIRECTORY) continue;
+
 		if (isRequestForSwitchProtocol(echoBuffer, recvMsgSize)) {
 			ServerResponeSwitchProtocol(&usingTCP, sock, echoServAddr, PORT);
 			if (usingTCP) {
@@ -57,8 +60,6 @@ int main(){
 					ErrorHandling("Accept failed");
 			}
 		}
-
-		if (createServerDirectory(echoBuffer) == BEGIN_DIRECTORY) continue;
 
 		printf("Handling client %s\n", inet_ntoa(echoClntAddr.sin_addr));
 


### PR DESCRIPTION
- 클라이언트에서 변경을 요청하고, 서버가 그에 맞춰 변경 후 응답한다.
- 파일을 전송하기 직전에 전환하고, 전송이 끝난 후 복귀하도록 변경
- 파일의 크기가 버퍼보다 2배 이상 큰 경우 TCP로 전환하여 전송한다
- 일부 코드의 위치 조정
- 파일 전송 포트를 8888로 고정
